### PR TITLE
fix: change moduleResolution

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "jsx": "preserve",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,21 +1,19 @@
+import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
-import tailwindcss from '@tailwindcss/vite';
 
 import path from "path";
 
 export default defineConfig({
   plugins: [
     solidPlugin(),
-    tailwindcss({
-      config: './tailwind.config.js',
-    }),
+    tailwindcss(),
   ],
   server: {
     port: 3000,
     proxy: {
       '/auth': {
-        target: 'http://localhost:4000',
+        target: 'http://192.168.3.23:4000',
         changeOrigin: true,
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {
@@ -30,23 +28,23 @@ export default defineConfig({
         },
       },
       '/api/': {
-        target: 'http://localhost:4000',
+        target: 'http://192.168.3.23:4000',
         changeOrigin: true,
       },
       '/oidc': {
-        target: 'http://localhost:4001',
+        target: 'http://192.168.3.23:4001',
         changeOrigin: true,
       },
       '/oauth2': {
-        target: 'http://localhost:4001',
+        target: 'http://192.168.3.23:4001',
         changeOrigin: true,
       },
       '/idm': {
-        target: 'http://localhost:4000',
+        target: 'http://192.168.3.23:4000',
         changeOrigin: true,
       },
       '/profile': {
-        target: 'http://localhost:4000',
+        target: 'http://192.168.3.23:4000',
         changeOrigin: true,
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/auth': {
-        target: 'http://192.168.3.23:4000',
+        target: 'http://localhost:4000',
         changeOrigin: true,
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {
@@ -28,23 +28,23 @@ export default defineConfig({
         },
       },
       '/api/': {
-        target: 'http://192.168.3.23:4000',
+        target: 'http://localhost:4000',
         changeOrigin: true,
       },
       '/oidc': {
-        target: 'http://192.168.3.23:4001',
+        target: 'http://localhost:4001',
         changeOrigin: true,
       },
       '/oauth2': {
-        target: 'http://192.168.3.23:4001',
+        target: 'http://localhost:4001',
         changeOrigin: true,
       },
       '/idm': {
-        target: 'http://192.168.3.23:4000',
+        target: 'http://localhost:4000',
         changeOrigin: true,
       },
       '/profile': {
-        target: 'http://192.168.3.23:4000',
+        target: 'http://localhost:4000',
         changeOrigin: true,
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/459e9aa3-8e3e-460c-b7ae-323a0590f488)

![image](https://github.com/user-attachments/assets/3b2d7604-a74d-4e83-a7e5-fdb31be1a3b1)

![image](https://github.com/user-attachments/assets/cfdfaa36-b711-48c6-b518-491b7b9b68a0)

![image](https://github.com/user-attachments/assets/d4a00de4-4f5a-43dc-b35c-57ba87645e23)

基于 [vite 文档](https://vite.dev/guide/performance.html#reduce-resolve-operations)，当moduleResolution 为“node”时会出现一下某些 ts 类型会失效，
以及官网推荐使用 bundler ，
以及根据 @tailwindcss/vite 的类型文件可知， tailwindcss 函数没有参数