### PR TITLE
FEAT: update email mask for 2fa send email selection

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -105,11 +105,13 @@ func MaskEmail(email string) string {
 	localPart := parts[0]
 	domain := parts[1]
 
-	// Show first character and mask the rest, keeping the domain
-	if len(localPart) > 1 {
-		return localPart[:1] + "***@" + domain
+	// Show first and last character, mask the middle
+	if len(localPart) > 2 {
+		return localPart[:1] + "***" + localPart[len(localPart)-1:] + "@" + domain
+	} else if len(localPart) == 2 {
+		return localPart[:1] + "*" + localPart[1:] + "@" + domain
 	}
-	return "***@" + domain
+	return localPart + "@" + domain // For single character local parts, don't mask
 }
 
 // NullStringToNullUUID converts a sql.NullString to uuid.NullUUID


### PR DESCRIPTION
The new function now:

Shows the first character of the local part
Adds asterisks in the middle
Shows the last character of the local part
Keeps the domain intact
For example:

user@mail.com becomes u***r@mail.com
john.doe@example.com becomes j***e@example.com
ab@test.com becomes a*b@test.com
a@test.com remains a@test.com (single character local parts aren't masked)