### PR TITLE
feat: redesign 2FA email template with Torpago branding

### DIFF
--- a/pkg/notice/templates/email/2fa_code_notice.html
+++ b/pkg/notice/templates/email/2fa_code_notice.html
@@ -1,1 +1,183 @@
-Here is your 2FA passcode: {{.TwofaPasscode}}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html
+  lang="en"
+  style="height:100%;font-family:-apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Roboto&#x27;, &#x27;Oxygen&#x27;, &#x27;Ubuntu&#x27;, &#x27;Cantarell&#x27;, &#x27;Fira Sans&#x27;, &#x27;Droid Sans&#x27;, &#x27;Helvetica Neue&#x27;, sans-serif"
+>
+  <div id="__react-email-preview" style="display: none; line-height: 1px">
+    Two-Factor Authentication Code
+    <div></div>
+  </div>
+
+  <div data-id="__react-email-body" style="width: 100%; height: 100%">
+    <div style="background-color: #121d25; padding: 30px 0">
+      <div style="max-width: 37.5em; margin: auto">
+        <img
+          data-id="react-email-img"
+          alt="Torpago&#x27;s Logo"
+          src="https://torpagowebsite.s3.amazonaws.com/images/torpagologo.png"
+          width="200"
+          style="display: block; border: none; text-decoration: none"
+        />
+      </div>
+    </div>
+
+    <div style="width: 100%; background-color: #212f39">
+      <div style="margin: auto; width: fit-content">
+        <table
+          align="center"
+          width="100%"
+          data-id="__react-email-container"
+          role="presentation"
+          cellspacing="0"
+          cellpadding="0"
+          border="0"
+          style="max-width: 37.5em"
+        >
+          <tbody>
+            <tr style="width: 100%">
+              <td>
+                <h1
+                  data-id="react-email-heading"
+                  style="color: #b3e5ef; margin: 40px 0"
+                >
+                  Hi {{.Username}},
+                </h1>
+
+                <p
+                  data-id="react-email-text"
+                  style="
+                    font-size: 14px;
+                    line-height: 24px;
+                    margin: 24px 0;
+                    color: #ffffff;
+                    margin-bottom: 16px;
+                  "
+                >
+                  Your two-factor authentication code is:
+                </p>
+
+                <div style="text-align: center; margin: 30px 0">
+                  <div
+                    style="
+                      background-color: #245b6c;
+                      color: #ffffff;
+                      border-radius: 8px;
+                      font-size: 24px;
+                      font-weight: bold;
+                      text-align: center;
+                      display: inline-block;
+                      padding: 20px 30px;
+                      letter-spacing: 8px;
+                      font-family: monospace;
+                    "
+                  >
+                    {{.TwofaPasscode}}
+                  </div>
+                </div>
+
+                <p
+                  data-id="react-email-text"
+                  style="
+                    font-size: 14px;
+                    line-height: 24px;
+                    margin: 24px 0;
+                    color: #ffffff;
+                    margin-bottom: 16px;
+                  "
+                >
+                  If you did not request this code, please ignore this email or
+                  contact our support team immediately.
+                </p>
+
+                <p
+                  data-id="react-email-text"
+                  style="
+                    font-size: 14px;
+                    line-height: 24px;
+                    margin: 24px 0;
+                    color: #ffffff;
+                    margin-bottom: 16px;
+                    margin-top: 14px;
+                  "
+                >
+                  If you have any questions or would like to discuss this
+                  further, please contact the Torpago Card support team at<a
+                    href="mailto:support@torpago.com"
+                    data-id="react-email-link"
+                    target="_blank"
+                    style="color: #2754c5; font-size: 14px"
+                  >
+                    support@torpago.com</a
+                  >
+                  or 650-623-5429.
+                </p>
+                <p
+                  data-id="react-email-text"
+                  style="
+                    font-size: 14px;
+                    line-height: 24px;
+                    margin: 12px 0 24px 0;
+                    color: #ffffff;
+                  "
+                >
+                  Torpago Team
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div style="background-color: #121d25; padding: 30px 0; width: 100%">
+      <div style="max-width: 37.5em; margin: auto">
+        <div style="display: inline-block; color: #fff; width: 80%">
+          <div style="padding-right: 24px; display: inline-block">
+            <p
+              data-id="react-email-text"
+              style="font-size: 14px; line-height: 24px; margin: 4px 0"
+            >
+              2024 Torpago, Inc
+            </p>
+            <a
+              href="https://www.torpago.com"
+              data-id="react-email-link"
+              target="_blank"
+              style="color: #067df7"
+              >torpago.com</a
+            >
+          </div>
+          <div style="display: inline-block">
+            <p
+              data-id="react-email-text"
+              style="font-size: 14px; line-height: 24px; margin: 4px 0"
+            >
+              228 Lorton Ave
+            </p>
+            <p
+              data-id="react-email-text"
+              style="font-size: 14px; line-height: 24px; margin: 4px 0"
+            >
+              Burlingame, CA 94010
+            </p>
+          </div>
+        </div>
+        <div style="margin-top: 9px; display: inline-block">
+          <a
+            href="https://www.linkedin.com/company/torpago"
+            data-id="react-email-link"
+            target="_blank"
+            style="color: #067df7; text-decoration: none"
+            ><img
+              data-id="react-email-img"
+              alt="linkedinicon"
+              src="https://torpagowebsite.s3.amazonaws.com/images/linkedin.png"
+              width="32"
+              height="32"
+              style="display: block; border: none; text-decoration: none"
+          /></a>
+        </div>
+      </div>
+    </div>
+  </div>
+</html>


### PR DESCRIPTION
- Convert plain text 2FA email to styled HTML template
- Add Torpago branding with logo and color scheme
- Improve user experience with better visual hierarchy
- Include support contact information
- Add responsive design for email clients

🤖 Generated with [Claude Code](https://claude.ai/code)